### PR TITLE
[WIP] Improve the functions in Page Objects to be more generic

### DIFF
--- a/lib/src/pageObjects/adminUIListScreen.js
+++ b/lib/src/pageObjects/adminUIListScreen.js
@@ -2,14 +2,6 @@ module.exports = {
 	elements: {
 		noItemsFoundNoText: '.BlankState__heading',
 		singleItemDeleteIcon: '.ItemList__control--delete',
-		firstItemDeleteIcon: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td[contains(concat(" ", normalize-space(@class), " "), "ItemList__col--control ItemList__col--delete")][1]',
-		},
-		secondItemDeleteIcon: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td[contains(concat(" ", normalize-space(@class), " "), "ItemList__col--control ItemList__col--delete")][1]',
-		},
 		itemDeleteIcon: '.Table.ItemList .ItemList__col--control.ItemList__col--delete',
 		searchInputField: '[data-search-input-field]',
 		searchInputFieldClearIcon: '[data-search-input-field-clear-icon]',
@@ -17,45 +9,10 @@ module.exports = {
 		columnDropdown: '#listHeaderColumnButton',
 		downloadDropdown: '#listHeaderDownloadButton',
 		expandTableIcon: 'div.InputGroup_section:nth-child(5) > button:nth-child(1)',
+		createItemButton: 'button[data-e2e-list-create-button]',
 		createFirstItemButton: 'button[data-e2e-list-create-button="no-results"]',
 		createMoreItemsButton: 'button[data-e2e-list-create-button="header"]',
 		paginationCount: '.Pagination__count',
-		firstColumnHeader: {
-			locateStrategy: 'xpath',
-			selector: '//thead/tr[1]/th[2]/button[contains(@class, "ItemList__sort-button th-sort")]',
-		},
-		secondColumnHeader: {
-			locateStrategy: 'xpath',
-			selector: '//thead/tr[1]/th[3]/button[contains(@class, "ItemList__sort-button th-sort")]',
-		},
-		thirdColumnHeader: {
-			locateStrategy: 'xpath',
-			selector: '//thead/tr[1]/th[4]/button[contains(@class, "ItemList__sort-button th-sort")]',
-		},
-		firstItemFirstColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td[2]',
-		},
-		firstItemSecondColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td[3]',
-		},
-		firstItemThirdColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td[4]',
-		},
-		secondItemFirstColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td[2]',
-		},
-		secondItemSecondColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td[3]',
-		},
-		secondItemThirdColumnValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td[4]',
-		},
 		firstUserItemIsNotAdmin: {
 			locateStrategy: 'xpath',
 			selector: '//tbody/tr[1]/td[4]/div/span[contains(@class, "octicon-x")]',
@@ -72,39 +29,71 @@ module.exports = {
 			locateStrategy: 'xpath',
 			selector: '//tbody/tr[2]/td[5]/div/span[contains(@class, "octicon-x")]',
 		},
-		firstItemLink: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td[2]/a',
-		},
-		secondItemLink: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td[2]/a',
-		},
-		thirdItemLink: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[3]/td[2]/a',
-		},
-		firstItemNameValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[1]/td/a[contains(@class, "ItemList__value ItemList__value--text")][1]',
-		},
-		secondItemNameValue: {
-			locateStrategy: 'xpath',
-			selector: '//tbody/tr[2]/td/a[contains(@class, "ItemList__value ItemList__value--text")][1]',
-		},
 	},
 	commands: [{
-		deleteItem: function (selector) {
+		assertNthColumnHeaderContains: function (n, value) {
+			return this.expect.element(getNthColumnHeaderSelector(n)).text.to.contain(value);
+		},
+		assertNthColumnHeaderEquals: function (n, value) {
+			return this.expect.element(getNthColumnHeaderSelector(n)).text.to.equal(value);
+		},
+		assertIthItemJthColumnContains: function (i, j, value) {
+			return this.expect.element(getIthItemJthColumnSelector(i, j)).text.to.contain(value);
+		},
+		assertIthItemJthColumnEquals: function (i, j, value) {
+			return this.expect.element(getIthItemJthColumnSelector(i, j)).text.to.equal(value);
+		},
+		createItem: function () {
 			return this
-				.click(selector);
+				.click('@createItemButton');
 		},
 		createFirstItem: function () {
 			return this
 				.click('@createFirstItemButton');
 		},
-		navigateToFirstItem: function () {
+		createMoreItems: function () {
 			return this
-				.click('@firstItemLink');
+				.click('@createMoreItemsButton');
+		},
+		deleteNthItem: function (n) {
+			return this
+				.click(getNthItemDeleteIconSelector(n));
+		},
+		navigateToNthItem: function (n) {
+			return this
+				.click(getNthItemLinkSelector(n));
+		},
+
+		// The following block of commands simply provide more user-friendly names for specific cases of the above commands.
+		// The commands in this block should only call commands which are defined above.
+
+		assertFirstItemNameEquals: function (value) {
+			this.assertIthItemJthColumnEquals(1, 1, value);
+		},
+		assertFirstItemNameContains: function (value) {
+			this.assertIthItemJthColumnContains(1, 1, value);
+		},
+		deleteFirstItem: function () {
+			return this.deleteNthItem(1);
+		},
+		navigateToFirstItem: function () {
+			return this.navigateToNthItem(1);
 		},
 	}],
 };
+
+function getNthItemDeleteIconSelector (n) {
+	return '.ItemList-wrapper tbody tr:nth-of-type(' + n + ') td:nth-of-type(1) button';
+}
+
+function getNthItemLinkSelector (n) {
+	return '.ItemList-wrapper tbody tr:nth-of-type(' + n + ') td:nth-of-type(2) a';
+}
+
+function getNthColumnHeaderSelector (n) {
+	return '.ItemList-wrapper thead th:nth-of-type(' + (n + 1) + ')';
+}
+
+function getIthItemJthColumnSelector (i, j) {
+	return '.ItemList-wrapper tbody tr:nth-of-type(' + i + ') td:nth-of-type(' + (j + 1) + ')';
+}


### PR DESCRIPTION
This starts work on making the page objects more useful to the general user. 

I feel we should:
- [ ] Change all functions like `doSomethingWithFirstThing` to be `doSomethingWithNthThing (n)`. This means we don't have to write out lots of functions and selectors, and so would improve the code in our page objects. 
- [ ] Ensure we expose as many of the nightwatch functions as possible. For example, whenever we provide a function which checks whether some text is equal to a given input, we should also provide the equivalent functions to check the text contains the given input, is not equal to the given input, and does not contain the given input. 

The first point seems to mainly relate to `adminUIListScreen` since, by nature of being a list, this is where we'd like to select Nth items. 
