### PR TITLE
Added wysiwyg option to html field test object

### DIFF
--- a/lib/src/fieldTestObjects/HtmlFieldTestObject.js
+++ b/lib/src/fieldTestObjects/HtmlFieldTestObject.js
@@ -12,6 +12,7 @@ module.exports = function HtmlFieldTestObject (config) {
 		elements: {
 			label: '.FormLabel',
 			value: 'textarea[name="' + config.fieldName + '"]',
+			wysiwyg: 'iframe',
 		},
 		listScreenElements: {
 			ui: 'a.ItemList__value',
@@ -24,8 +25,13 @@ module.exports = function HtmlFieldTestObject (config) {
 					.expect.element(selectElem('label')).to.be.visible;
 				browser
 					.expect.element(selectElem('label')).text.to.equal(utils.titlecase(config.fieldName));
-				browser
-					.expect.element(selectElem('value')).to.be.visible;
+				if (options && options.wysiwyg) {
+					browser
+						.expect.element(selectElem('wysiwyg')).to.be.visible;
+				} else {
+					browser
+						.expect.element(selectElem('value')).to.be.visible;
+				}
 				return browser;
 			},
 			assertFieldUINotVisible: function (browser, options) {
@@ -33,38 +39,79 @@ module.exports = function HtmlFieldTestObject (config) {
 					.expect.element(selectElem('label')).to.not.be.visible;
 				browser
 					.expect.element(selectElem('label')).text.to.equal(utils.titlecase(config.fieldName));
-				browser
-					.expect.element(selectElem('value')).to.not.be.visible;
+				if (options && options.wysiwyg) {
+					browser
+						.expect.element(selectElem('wysiwyg')).to.not.be.visible;
+				} else {
+					browser
+						.expect.element(selectElem('value')).to.not.be.visible;
+				}
 				return browser;
 			},
 			assertFieldDOMPresent: function (browser, options) {
 				browser
 					.expect.element(selectElem('label')).to.be.present;
-				browser
-					.expect.element(selectElem('value')).to.be.present;
+				if (options && options.wysiwyg) {
+					browser
+						.expect.element(selectElem('wysiwyg')).to.be.present;
+				} else {
+					browser
+						.expect.element(selectElem('value')).to.be.present;
+				}
 				return browser;
 			},
 			assertFieldDOMNotPresent: function (browser, options) {
 				browser
 					.expect.element(selectElem('label')).to.not.be.present;
-				browser
-					.expect.element(selectElem('value')).to.not.be.present;
+				if (options && options.wysiwyg) {
+					browser
+						.expect.element(selectElem('wysiwyg')).to.not.be.present;
+				} else {
+					browser
+						.expect.element(selectElem('value')).to.not.be.present;
+				}
 				return browser;
 			},
-			fillFieldInputs: function (browser, input, options) {
-				browser
-					.clearValue(selectElem('value'))
-					.setValue(selectElem('value'), input.value);
+			fillFieldInputs: function (browser, input) {
+				if (input.options && input.options.wysiwyg) {
+					browser
+						.waitForElementVisible(selectElem('wysiwyg'))
+						.click(selectElem('wysiwyg'));
+					browser.api
+						.execute(function (selector, input) {
+							var body = document.querySelector('.field-type-html[for="description"]')
+								.querySelector('iframe').contentDocument.querySelector('.mce-content-body');
+							body.innerHTML = input.value;
+						}, [self.selector, input]);
+				} else {
+					browser
+						.clearValue(selectElem('value'))
+						.setValue(selectElem('value'), input.value);
+				}
 				return browser;
 			},
-			assertFieldInputs: function (browser, input, options) {
-				browser
-					.waitForElementVisible(selectElem('value'));
-				browser
-					.getValue(selectElem('value'), function (result) {
-						browser.api.assert.equal(result.state, 'success');
-						browser.api.assert.equal(result.value, input.value);
-					});
+			assertFieldInputs: function (browser, input) {
+				if (input.options && input.options.wysiwyg) {
+					browser
+						.waitForElementVisible(selectElem('wysiwyg'));
+					browser.api
+						.execute(function (selector) {
+							var body = document.querySelector('.field-type-html[for="description"]')
+								.querySelector('iframe').contentDocument.querySelector('.mce-content-body');
+							return body.innerHTML;
+						}, [self.selector], function (result) {
+							console.log(result.value);
+							browser.assert.equal(result.value, input.value);
+						});
+				} else {
+					browser
+						.waitForElementVisible(selectElem('value'));
+					browser
+						.getValue(selectElem('value'), function (result) {
+							browser.api.assert.equal(result.state, 'success');
+							browser.api.assert.equal(result.value, input.value);
+						});
+				}
 				return browser;
 			},
 			assertListScreenFieldUIVisible: function (browser, options) {

--- a/lib/src/pageObjects/adminUIInitialForm.js
+++ b/lib/src/pageObjects/adminUIInitialForm.js
@@ -42,21 +42,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldUIVisible' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldUIVisible(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldUIVisible' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldUIVisible(browser, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: assertFieldUIVisible command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: assertFieldUIVisible command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:assertFieldUIVisible: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:assertFieldUIVisible: invalid field name!');
+						throw new Error('adminUIInitialForm:assertFieldUIVisible: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:assertFieldUIVisible: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:assertFieldUIVisible: Invalid field specification!');
 			}
@@ -77,21 +78,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldUINotVisible' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldUINotVisible(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldUINotVisible' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldUINotVisible(browser, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: assertFieldUINotVisible command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: assertFieldUINotVisible command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:assertFieldUINotVisible: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:assertFieldUINotVisible: invalid field name!');
+						throw new Error('adminUIInitialForm:assertFieldUINotVisible: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:assertFieldUINotVisible: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:assertFieldUINotVisible: Invalid field specification!');
 			}
@@ -112,21 +114,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldDOMPresent' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldDOMPresent(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldDOMPresent' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldDOMPresent(browser, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: assertFieldDOMPresent command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: assertFieldDOMPresent command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:assertFieldDOMPresent: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:assertFieldDOMPresent: invalid field name!');
+						throw new Error('adminUIInitialForm:assertFieldDOMPresent: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:assertFieldDOMPresent: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:assertFieldDOMPresent: Invalid field specification!');
 			}
@@ -147,21 +150,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldDOMNotPresent' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldDOMNotPresent(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldDOMNotPresent' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldDOMNotPresent(browser, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: assertFieldDOMNotPresent command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: assertFieldDOMNotPresent command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:assertFieldDOMNotPresent: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:assertFieldDOMNotPresent: invalid field name!');
+						throw new Error('adminUIInitialForm:assertFieldDOMNotPresent: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:assertFieldDOMNotPresent: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:assertFieldDOMNotPresent: Invalid field specification!');
 			}
@@ -183,21 +187,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'clickFieldUI' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.clickFieldUI(browser, field.click, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'clickFieldUI' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.clickFieldUI(browser, field.click, field.options);
+							} else {
+								throw new Error('adminUIInitialForm:clickFieldUI command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm:clickFieldUI command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:clickFieldUI: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:clickFieldUI: invalid field name!');
+						throw new Error('adminUIInitialForm:clickFieldUI: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:clickFieldUI: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:clickFieldUI: Invalid field specification!');
 			}
@@ -219,21 +224,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'fillFieldInputs' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.fillFieldInputs(browser, field.input, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'fillFieldInputs' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.fillFieldInputs(browser, field.input, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: fillFieldInputs command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: fillFieldInputs command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:fillFieldInputs: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:fillFieldInputs: invalid field name!');
+						throw new Error('adminUIInitialForm:fillFieldInputs: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:fillFieldInputs: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:fillFieldInputs: Invalid field specification!');
 			}
@@ -255,21 +261,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldInputs' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldInputs(browser, field.input, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldInputs' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldInputs(browser, field.input, field.options);
+							} else {
+								throw new Error('adminUIInitialForm: assertFieldInputs command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIInitialForm: assertFieldInputs command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIInitialForm:assertFieldInputs: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIInitialForm:assertFieldInputs: invalid field name!');
+						throw new Error('adminUIInitialForm:assertFieldInputs: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIInitialForm:assertFieldInputs: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIInitialForm:assertFieldInputs: Invalid field specification!');
 			}

--- a/lib/src/pageObjects/adminUIItemScreen.js
+++ b/lib/src/pageObjects/adminUIItemScreen.js
@@ -67,21 +67,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldUIVisible' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldUIVisible(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldUIVisible' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldUIVisible(browser, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:assertFieldUIVisible command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:assertFieldUIVisible command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:assertFieldUIVisible: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:assertFieldUIVisible: invalid field name!');
+						throw new Error('adminUIItemScreen:assertFieldUIVisible: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:assertFieldUIVisible: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:assertFieldUIVisible: Invalid field specification!');
 			}
@@ -102,21 +103,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldUINotVisible' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldUINotVisible(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldUINotVisible' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldUINotVisible(browser, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:assertFieldUINotVisible command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:assertFieldUINotVisible command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:assertFieldUINotVisible: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:assertFieldUINotVisible: invalid field name!');
+						throw new Error('adminUIItemScreen:assertFieldUINotVisible: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:assertFieldUINotVisible: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:assertFieldUINotVisible: Invalid field specification!');
 			}
@@ -137,21 +139,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldDOMPresent' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldDOMPresent(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldDOMPresent' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldDOMPresent(browser, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:assertFieldDOMPresent command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:assertFieldDOMPresent command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:assertFieldDOMPresent: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:assertFieldDOMPresent: invalid field name!');
+						throw new Error('adminUIItemScreen:assertFieldDOMPresent: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:assertFieldDOMPresent: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:assertFieldDOMPresent: Invalid field specification!');
 			}
@@ -172,21 +175,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldDOMNotPresent' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldDOMNotPresent(browser, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldDOMNotPresent' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldDOMNotPresent(browser, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:assertFieldDOMNotPresent command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:assertFieldDOMNotPresent command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:assertFieldDOMNotPresent: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:assertFieldDOMNotPresent: invalid field name!');
+						throw new Error('adminUIItemScreen:assertFieldDOMNotPresent: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:assertFieldDOMNotPresent: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:assertFieldDOMNotPresent: Invalid field specification!');
 			}
@@ -208,21 +212,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'clickFieldUI' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.clickFieldUI(browser, field.click, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'clickFieldUI' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.clickFieldUI(browser, field.click, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:clickFieldUI command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:clickFieldUI command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:clickFieldUI: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:clickFieldUI: invalid field name!');
+						throw new Error('adminUIItemScreen:clickFieldUI: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:clickFieldUI: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:clickFieldUI: Invalid field specification!');
 			}
@@ -244,21 +249,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'fillFieldInputs' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.fillFieldInputs(browser, field.input, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'fillFieldInputs' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.fillFieldInputs(browser, field.input, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:fillFieldInputs command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:fillFieldInputs command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:fillFieldInputs: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:fillFieldInputs: invalid field name!');
+						throw new Error('adminUIItemScreen:fillFieldInputs: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:fillFieldInputs: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:fillFieldInputs: Invalid field specification!');
 			}
@@ -280,21 +286,22 @@ module.exports = {
 			var form = this.section.form;
 			if (fields) {
 				fields.forEach(function (field) {
-				form.section.list = new field.modelTestConfig({ formSelector: form.selector });
-				if (form.section.list) {
-					var fieldTestObject = form.section.list[field.name];
-					if (fieldTestObject) {
-						if (fieldTestObject.commands && 'assertFieldInputs' in fieldTestObject.commands) {
-							form.section.list[field.name].commands.assertFieldInputs(browser, field.input, field.options);
+					form.section.list = new field.modelTestConfig({ formSelector: form.selector });
+					if (form.section.list) {
+						var fieldTestObject = form.section.list[field.name];
+						if (fieldTestObject) {
+							if (fieldTestObject.commands && 'assertFieldInputs' in fieldTestObject.commands) {
+								form.section.list[field.name].commands.assertFieldInputs(browser, field.input, field.options);
+							} else {
+								throw new Error('adminUIItemScreen:assertFieldInputs command not defined in ' + field.name + ' field test object!');
+							}
 						} else {
-							throw new Error('adminUIItemScreen:assertFieldInputs command not defined in ' + field.name + ' field test object!');
+							throw new Error('adminUIItemScreen:assertFieldInputs: invalid field name!');
 						}
 					} else {
-						throw new Error('adminUIItemScreen:assertFieldInputs: invalid field name!');
+						throw new Error('adminUIItemScreen:assertFieldInputs: invalid field modelTestConfig!');
 					}
-				} else {
-					throw new Error('adminUIItemScreen:assertFieldInputs: invalid field modelTestConfig!');
-				}});
+				});
 			} else {
 				throw new Error('adminUIItemScreen:assertFieldInputs: Invalid field specification!');
 			}


### PR DESCRIPTION
Currently testing is completely impossible for html fields with tinymce. This is because the tests look for a `textarea` but should instead look for an `iframe` in this case. 

@webteckie If this won't cause conflicts with your work, then merge it. Otherwise, we'll just leave this open until you're done refactoring and then deal with the conflicts in this PR. 
