### PR TITLE
22e refactor po api

### DIFF
--- a/lib/src/pageObjects/adminUIApp.js
+++ b/lib/src/pageObjects/adminUIApp.js
@@ -2,6 +2,7 @@
 	This page object describes global admin UI configuration and commands that are or should be
 	most likely available in all pages.
  */
+var objectAssign = require('object-assign');
 var e2e = require('../../..');
 var keystone = e2e.keystone;
 var utils = require('keystone-utils');
@@ -11,120 +12,435 @@ module.exports = {
 	pause: 1000,
 	elements: {
 		// ADMIN UI APP SCREENS
+		/**
+		 * The signin screen element
+		 */
 		signinScreen: '#signin-view',
+
+		/**
+		 * The home screen element
+		 */
 		homeScreen: 'div[data-screen-id="home"]',
+
+		/**
+		 * The list screen element
+		 */
 		listScreen: 'div[data-screen-id="list"]',
+
+		/**
+		 * The edit item screen element
+		 */
 		itemScreen: 'div[data-screen-id="item"]',
+
+		/**
+		 * The create item form screen element
+		 */
 		initialFormScreen: '.Modal-dialog',
+
+		/**
+		 * The delete confirmation screen element
+		 */
 		deleteConfirmationScreen: '.Modal-dialog',
+
+		/**
+		 * The reset confirmation screen element
+		 */
 		resetConfirmationScreen: '.Modal-dialog',
 
-		// APP LEVEL MENU
+		// APP LINKS
+		/**
+		 * The home icon element.
+		 */
 		homeIcon: '.primary-navbar [data-section-label="octicon-home"]',
+
+		/**
+		 * The home icon link element.
+		 */
 		homeIconLink: '.primary-navbar [data-section-label="octicon-home"] a',
+
+		/**
+		 * The frontend page icon element.
+		 */
 		frontPageIcon: '.primary-navbar [data-section-label="octicon-globe"]',
+
+		/**
+		 * The frontend page icon link element.
+		 */
 		frontPageIconLink: '.primary-navbar [data-section-label="octicon-globe"] a',
+
+		/**
+		 * The logout icon element.
+		 */
 		logoutIcon: '.primary-navbar [data-section-label="octicon-sign-out"]',
+
+		/**
+		 * The logout icon link element.
+		 */
 		logoutIconLink: '.primary-navbar [data-section-label="octicon-sign-out"] a',
 
-		// LIST NAV MENU
-		accessMenu: '.primary-navbar [data-section-label="Access"]',
-		fieldListsMenu: '.primary-navbar [data-section-label="Fields"]',
-		miscListsMenu: '.primary-navbar [data-section-label="Miscs"]',
-		booleanListSubmenu: '.secondary-navbar [data-list-path="booleans"]',
-		cloudinaryimageListSubmenu: '.secondary-navbar [data-list-path="cloudinary-images"]',
-		cloudinaryimagemultipleListSubmenu: '.secondary-navbar [data-list-path="cloudinary-image-multiples"]',
-		codeListSubmenu: '.secondary-navbar [data-list-path="codes"]',
-		colorListSubmenu: '.secondary-navbar [data-list-path="colors"]',
-		datearrayListSubmenu: '.secondary-navbar [data-list-path="date-arrays"]',
-		dateListSubmenu: '.secondary-navbar [data-list-path="dates"]',
-		datetimeListSubmenu: '.secondary-navbar [data-list-path="datetimes"]',
-		emailListSubmenu: '.secondary-navbar [data-list-path="emails"]',
-		fileListSubmenu: '.secondary-navbar [data-list-path="files"]',
-		geopointListSubmenu: '.secondary-navbar [data-list-path="geo-points"]',
-		htmlListSubmenu: '.secondary-navbar [data-list-path="htmls"]',
-		keyListSubmenu: '.secondary-navbar [data-list-path="keys"]',
-		locationListSubmenu: '.secondary-navbar [data-list-path="locations"]',
-		markdownListSubmenu: '.secondary-navbar [data-list-path="markdowns"]',
-		moneyListSubmenu: '.secondary-navbar [data-list-path="money"]',
-		nameListSubmenu: '.secondary-navbar [data-list-path="names"]',
-		numberarrayListSubmenu: '.secondary-navbar [data-list-path="number-arrays"]',
-		numberListSubmenu: '.secondary-navbar [data-list-path="numbers"]',
-		passwordListSubmenu: '.secondary-navbar [data-list-path="passwords"]',
-		relationshipListSubmenu: '.secondary-navbar [data-list-path="relationships"]',
-		selectListSubmenu: '.secondary-navbar [data-list-path="selects"]',
-		textareaListSubmenu: '.secondary-navbar [data-list-path="textareas"]',
-		textarrayListSubmenu: '.secondary-navbar [data-list-path="text-arrays"]',
-		textListSubmenu: '.secondary-navbar [data-list-path="texts"]',
-		urlListSubmenu: '.secondary-navbar [data-list-path="urls"]',
+		/**
+		 * The primary navbar element.
+		 */
+		primaryNavbar: '.primary-navbar',
 
-		// FIX ME NAV MENU
-		datefieldmapListSubmenu: '.secondary-navbar [data-list-path="date-field-maps"]',
-		dependsonListSubmenu: '.secondary-navbar [data-list-path="depends-ons"]',
-		hiddenrelationshipListSubmenu: '.secondary-navbar [data-list-path="hidden-relationships"]',
-		inlinerelationshipListSubmenu: '.secondary-navbar [data-list-path="inline-relationships"]',
-		manyrelationshipListSubmenu: '.secondary-navbar [data-list-path="many-relationships"]',
-		nodefaultcolumnListSubmenu: '.secondary-navbar [data-list-path="no-default-columns"]',
-		sourcerelationshipListSubmenu: '.secondary-navbar [data-list-path="source-relationships"]',
-		targetrelationshipListSubmenu: '.secondary-navbar [data-list-path="target-relationships"]',
+		/**
+		 * The secondary navbar element.
+		 */
+		secondaryNavbar: '.secondary-navbar',
 	},
 	commands: [{
-		gotoSigninScreen: function () {
-			return this
-				.navigate();		// navigate to the configure Url
+		/**
+		 * Navigates to the signin screen.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {boolean} config.wait Whether to wait for the target UI.  Optional, defaults to true.
+		 */
+		gotoSigninScreen: function (config) {
+			var _config = objectAssign({}, { wait: true }, config);
+			this.navigate();
+			if (_config.wait) this.waitForSigninScreen();
+			return this;
 		},
-		gotoHomeScreen: function () {
-			return this
-				.navigate();		// navigate to the configure Url
+
+		/**
+		 * Navigates to the home screen.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {boolean} config.wait Whether to wait for the target UI.  Optional, defaults to true.
+		 */
+		gotoHomeScreen: function (config) {
+			var _config = objectAssign({}, { wait: true }, config);
+			this.navigate();
+			if (_config.wait) this.waitForHomeScreen();
+			return this;
 		},
+
+		/**
+		 * Opens the list of items given the specified list config spec.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.section The section in the primary navbar to click on.
+		 * @param {string} config.list The list in the secondary navbar to click on.
+		 * @param {boolean} config.wait Whether to wait for the target UI.  Optional, defaults to true.
+		 */
 		openList: function (config) {
-			return this.clickPrimaryNavbar(config.section)
-				.waitForElementVisible('.secondary-navbar')
-				.clickSecondaryNavbar(config.list)
-				.waitForListScreen();
+			var _config = objectAssign({}, { wait: true }, config);
+			this.clickPrimaryNavbar({ section: _config.section })
+				.waitForForSecondaryNavbar()
+				.clickSecondaryNavbar({ list: _config.list });
+			if (_config.wait) this.waitForListScreen();
+			return this;
 		},
-		clickPrimaryNavbar: function (key) {
-			var label = utils.keyToLabel(key);
-			return this.click('.primary-navbar li[data-section-label="' + label + '"]');
+
+		/**
+		 * Clicks the specified section in the primary navbar.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.section The section in the primary navbar to click on.
+		 * @param {boolean} config.wait Whether to wait for the target UI.  Optional, defaults to true.
+		 */
+		clickPrimaryNavbar: function (config) {
+			var _config = objectAssign({}, { wait: true }, config);
+			this
+				.click(this.getPrimaryNavbarSectionElement({ section: _config.section }));
+			if (_config.wait) this.waitForForSecondaryNavbar();
+			return this;
 		},
-		clickSecondaryNavbar: function (key) {
-			var path = utils.keyToPath(key, true);
-			return this.click('.secondary-navbar li[data-list-path="' + path + '"]');
+
+		/**
+		 * Clicks the specified list in the secondary navbar.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} list The list in the secondary navbar to click on.
+		 * @param {boolean} config.wait Whether to wait for the target UI.  Optional, defaults to true.
+		 */
+		clickSecondaryNavbar: function (config) {
+			var _config = objectAssign({}, { wait: true }, config);
+			this
+				.click(this.getSecondaryNavbarListElement({ list: _config.list }));
+			if (_config.wait) this.waitForListScreen();
+			return this;
 		},
-		signout: function () {
+
+		/**
+		 * Logout the current user.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {boolean} config.wait Whether to wait for the signin screen by default.  Optional, defaults to true.
+		 */
+		signout: function (config) {
+			var _config = objectAssign({}, { wait: true }, config);
 			this.api.pause(500);
-			return this
+			this
 				.waitForElementVisible('@logoutIcon')
-				.click('@logoutIconLink')
-				.waitForSigninScreen();
+				.click('@logoutIconLink');
+			if (_config.wait) this.waitForSigninScreen();
+			return this;
 		},
-		waitForSigninScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@signinScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the signin screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForSigninScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@signinScreen', _config.timeout);
 		},
-		waitForHomeScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@homeScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the home screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForHomeScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@homeScreen', _config.timeout);
 		},
-		waitForInitialFormScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@initialFormScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the create item form screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForInitialFormScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@initialFormScreen', _config.timeout);
 		},
-		waitForDeleteConfirmationScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@deleteConfirmationScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the delete confirmation screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForDeleteConfirmationScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@deleteConfirmationScreen', _config.timeout);
 		},
-		waitForResetConfirmationScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@resetConfirmationScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the reset confirmation screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForResetConfirmationScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@resetConfirmationScreen', _config.timeout);
 		},
-		waitForListScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@listScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the item list screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForListScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@listScreen', _config.timeout);
 		},
-		waitForItemScreen: function (timeout) {
-			return this
-				.waitForElementVisible('@itemScreen', timeout || this.api.globals.waitForConditionTimeout);
+
+		/**
+		 * Waits for the item edit form screen UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForItemScreen: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@itemScreen', _config.timeout);
+		},
+
+		/**
+		 * Waits for the secondary navbar UI to be visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {number} config.timeout Optional timeout to wait for.
+		 */
+		waitForForSecondaryNavbar: function (config) {
+			var _config = objectAssign({}, { timeout: this.api.globals.waitForConditionTimeout }, config);
+			return this.waitForElementVisible('@secondaryNavbar', _config.timeout);
+		},
+
+		/**
+		 * Asserts that the specified list screen element UI is visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose UI should be visible.
+		 */
+		assertElementIsVisible: function (config) {
+			return this.expect.element('@' + config.element).to.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified list screen element UI is not visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose UI should not be visible.
+		 */
+		assertElementIsNotVisible: function (config) {
+			return this.expect.element('@' + config.element).to.not.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified list screen element DOM is present.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose DOM should be present.
+		 */
+		assertElementIsPresent: function (config) {
+			return this.expect.element('@' + config.element).to.be.present;
+		},
+
+		/**
+		 * Asserts that the specified list screen element DOM is not present.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose DOM should not be present.
+		 */
+		assertElementIsNotPresent: function (config) {
+			return this.expect.element('@' + config.element).to.not.be.present;
+		},
+
+		/**
+		 * Asserts that the specified list screen element text equals the specified value.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose text should be compared to the input text.
+		 * @param {String} config.text The text to compare against.
+		 */
+		assertElementTextEquals: function (config) {
+			return this.expect.element('@' + config.element).text.to.equal(config.text);
+		},
+
+		/**
+		 * Asserts that the specified list screen element text not equals the specified value.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose text should be compared to the input text.
+		 * @param {String} config.text The text to compare against.
+		 */
+		assertElementTextNotEquals: function (config) {
+			return this.expect.element('@' + config.element).text.to.not.equal(config.text);
+		},
+
+		/**
+		 * Asserts that the specified list screen element text contains the specified value.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose text should contain the input text.
+		 * @param {String} config.text The text to compare against.
+		 */
+		assertElementTextContains: function (config) {
+			return this.expect.element('@' + config.element).text.to.contain(config.text);
+		},
+
+		/**
+		 * Asserts that the specified app screen element has the specified attribute.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose UI should be visible.
+		 * @param {string} config.attribute The attribute that should be present in the element.
+		 * @param {string} config.value The value that the attribute should have.
+		 */
+		assertElementHasAttribute: function (config) {
+			return this.expect.element('@' + config.element).to.have.attribute(config.attribute).which.contains(config.value);
+		},
+
+		/**
+		 * Asserts that the specified primary navbar section is visible.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.section The section that should be visible in the primary navbar.
+		 */
+		assertPrimaryNavbarSectionVisible: function (config) {
+			return this.expect.element(this.getPrimaryNavbarSectionElement({ section: config.section })).to.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified secondary navbar list is visible.  Make sure that the parent
+		 * primary navbar section is clicked on first.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.list The list that should be visible in the secondary navbar.
+		 */
+		assertSecondaryNavbarListVisible: function (config) {
+			return this.expect.element(this.getSecondaryNavbarListElement({ list: config.list })).to.be.visible;
+		},
+
+		/**
+		 * Clicks the specified UI element.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.element The element whose UI should be clicked.
+		 */
+		clickUIElement: function (config) {
+			return this.click('@' + config.element);
+		},
+
+		/**
+		 * Asserts that the specified css selector is visible.  This should be used for testing
+		 * frontend functionality only!
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.css The css selector to check for visibility.
+		 */
+		assertCssIsVisible: function (config) {
+			return this.expect.element(config.css).to.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified css contains the specified text.  This should be used for testing
+		 * frontend functionality only!
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.css The css selector containing the text.
+		 * @param {string} config.text The exact text that should be found at the css selector location.
+		 */
+		assertCssTextEquals: function (config) {
+			return this.expect.element(config.css).text.to.equal(config.text);
+		},
+
+		/**
+		 * Asserts that the specified css contains the specified text.  This should be used for testing
+		 * frontend functionality only!
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.css The css selector containing the text.
+		 * @param {string} config.text The exact or partial text that should be found at the css selector location.
+		 */
+		assertCssTextContains: function (config) {
+			return this.expect.element(config.css).text.to.contain(config.text);
+		},
+
+
+		//
+		// PRIVATE METHODS
+		//
+		/**
+		 * Gets the primary navbar section element.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.section The navbar section to get the element for.
+		 */
+		getPrimaryNavbarSectionElement: function (config) {
+			var label = utils.keyToLabel(config.section);
+			return '.primary-navbar li[data-section-label="' + label + '"]';
+		},
+
+		/**
+		 * Gets the secondary navbar list element.
+		 *
+		 * @param {Object} config The config spec.
+		 * @param {string} config.list The navbar list to get the element for.
+		 */
+		getSecondaryNavbarListElement: function (config) {
+			var path = utils.keyToPath(config.list, true);
+			return '.secondary-navbar li[data-list-path="' + path + '"]';
 		},
 	}],
 };

--- a/lib/src/pageObjects/adminUIHomeScreen.js
+++ b/lib/src/pageObjects/adminUIHomeScreen.js
@@ -27,6 +27,84 @@ var otherdashboardGroup = dashboardGroup({
 });
 
 module.exports = {
+	commands: [{
+		/**
+		 * Asserts that the specified list screen element UI is visible.
+		 *
+		 * @param {string} element The element whose UI should be visible.
+		 */
+		assertElementIsVisible: function (element) {
+			return this.expect.element('@' + element).to.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified list screen element UI is not visible.
+		 *
+		 * @param {string} element The element whose UI should not be visible.
+		 */
+		assertElementIsNotVisible: function (element) {
+			return this.expect.element('@' + element).to.not.be.visible;
+		},
+
+		/**
+		 * Asserts that the specified list screen element DOM is present.
+		 *
+		 * @param {string} element The element whose DOM should be present.
+		 */
+		assertElementIsPresent: function (element) {
+			return this.expect.element('@' + element).to.be.present;
+		},
+
+		/**
+		 * Asserts that the specified list screen element DOM is not present.
+		 *
+		 * @param {string} element The element whose DOM should not be present.
+		 */
+		assertElementIsNotPresent: function (element) {
+			return this.expect.element('@' + element).to.not.be.present;
+		},
+
+		/**
+		 * Asserts that the specified list screen element text equals the specified value.
+		 *
+		 * @param {string} element The element whose text should be compared to the input text.
+		 * @param {String} text The text to compare against.
+		 */
+		assertElementTextEquals: function (element, text) {
+			return this.expect.element('@' + element).text.to.equal(text);
+		},
+
+		/**
+		 * Asserts that the specified list screen element text not equals the specified value.
+		 *
+		 * @param {string} element The element whose text should be compared to the input text.
+		 * @param {String} text The text to compare against.
+		 */
+		assertElementTextNotEquals: function (element, text) {
+			return this.expect.element('@' + element).text.to.not.equal(text);
+		},
+
+		/**
+		 * Asserts that the specified list screen element text contains the specified value.
+		 *
+		 * @param {string} element The element whose text should contain the input text.
+		 * @param {String} text The text to compare against.
+		 */
+		assertElementTextContains: function (element, text) {
+			return this.expect.element('@' + element).text.to.contain(text);
+		},
+
+		/**
+		 * Asserts that the specified app screen element has the specified attribute.
+		 *
+		 * @param {string} element The element whose UI should be visible.
+		 * @param {string} attribute The attribute that should be present in the element.
+		 * @param {string} value The value that the attribute should have.
+		 */
+		assertElementHasAttribute: function (element, attribute, value) {
+			return this.expect.element('@' + element).to.have.attribute(attribute).which.contains(value);
+		},
+	}],
 	elements: {
 		dashboardHeader: '.dashboard-heading',
 	},

--- a/lib/src/pageObjects/adminUIInitialForm.js
+++ b/lib/src/pageObjects/adminUIInitialForm.js
@@ -83,6 +83,17 @@ module.exports = {
 		},
 
 		/**
+		 * Asserts that the specified app screen element has the specified attribute.
+		 *
+		 * @param {string} element The element whose UI should be visible.
+		 * @param {string} attribute The attribute that should be present in the element.
+		 * @param {string} value The value that the attribute should have.
+		 */
+		assertElementHasAttribute: function (element, attribute, value) {
+			return this.expect.element('@' + element).to.have.attribute(attribute).which.contains(value);
+		},
+
+		/**
 		 * Asserts that the specified item field's UI is visible in the initial form screen.  This command calls into the
 		 * assertFieldUIVisible command of the field under test, which gets passed the field.options.
 		 *

--- a/lib/src/pageObjects/adminUIItemScreen.js
+++ b/lib/src/pageObjects/adminUIItemScreen.js
@@ -82,6 +82,17 @@ module.exports = {
 		},
 
 		/**
+		 * Asserts that the specified app screen element has the specified attribute.
+		 *
+		 * @param {string} element The element whose UI should be visible.
+		 * @param {string} attribute The attribute that should be present in the element.
+		 * @param {string} value The value that the attribute should have.
+		 */
+		assertElementHasAttribute: function (element, attribute, value) {
+			return this.expect.element('@' + element).to.have.attribute(attribute).which.contains(value);
+		},
+
+		/**
 		 * Asserts that the specified item field's UI is visible in the edit item screen.  This command calls into the
 		 * assertFieldUIVisible command of the field under test, which gets passed the field.options.
 		 *

--- a/lib/src/pageObjects/adminUIListScreen.js
+++ b/lib/src/pageObjects/adminUIListScreen.js
@@ -85,6 +85,17 @@ module.exports = {
 		},
 
 		/**
+		 * Asserts that the specified app screen element has the specified attribute.
+		 *
+		 * @param {string} element The element whose UI should be visible.
+		 * @param {string} attribute The attribute that should be present in the element.
+		 * @param {string} value The value that the attribute should have.
+		 */
+		assertElementHasAttribute: function (element, attribute, value) {
+			return this.expect.element('@' + element).to.have.attribute(attribute).which.contains(value);
+		},
+
+		/**
 		 * Clicks the Search Input Clear icon in the list screen.
 		 */
 		clickSearchInputClearIcon: function () {

--- a/lib/src/pageObjects/adminUISignin.js
+++ b/lib/src/pageObjects/adminUISignin.js
@@ -1,27 +1,45 @@
+var objectAssign = require('object-assign');
+
 module.exports = {
 	elements: {
-		emailInput: {
-			selector: 'input[name=email]',
-		},
-		passwordInput: {
-			selector: 'input[name=password]',
-		},
-		submitButton: {
-			selector: 'button[type=submit]',
-		},
+		/**
+		 * The login email element.
+		 */
+		email: 'input[name=email]',
+
+		/**
+		 * The login password element.
+		 */
+		password: 'input[name=password]',
+
+		/**
+		 * The login submit button element.
+		 */
+		submitButton: 'button[type=submit]',
 	},
 	commands: [{
-		signin: function (user, password) {
-			return this
-				.setValue('@emailInput', user || 'user@test.e2e')
-				.setValue('@passwordInput', password || 'test')
+		/**
+		 * Signs in to the Admin UI.
+		 *
+		 * @param {Object} config The login info.
+		 * @param {string} config.user The login username/email.
+		 * @param {string} config.password The login password.
+		 * @param {boolean} config.wait Whether to wait for the home screen by default.  Optional, defaults to true.
+		 */
+		signin: function (config) {
+			var _config = objectAssign({}, { user: 'user@test.e2e', password: 'test', wait: true }, config);
+			this
+				.setValue('@emailInput', _config.user)
+				.setValue('@passwordInput', _config.password)
 				.click('@submitButton');
+			if (_config.wait) this.api.page.adminUIApp().waitForHomeScreen();
+			return this;
 		},
 		assertUI: function () {
 			this
-				.expect.element('@emailInput').to.be.visible;
+				.expect.element('@email').to.be.visible;
 			this
-				.expect.element('@passwordInput').to.be.visible;
+				.expect.element('@password').to.be.visible;
 			this
 				.expect.element('@submitButton').to.be.visible;
 			return this;

--- a/lib/src/pageObjects/adminUISignin.js
+++ b/lib/src/pageObjects/adminUISignin.js
@@ -29,8 +29,8 @@ module.exports = {
 		signin: function (config) {
 			var _config = objectAssign({}, { user: 'user@test.e2e', password: 'test', wait: true }, config);
 			this
-				.setValue('@emailInput', _config.user)
-				.setValue('@passwordInput', _config.password)
+				.setValue('@email', _config.user)
+				.setValue('@password', _config.password)
 				.click('@submitButton');
 			if (_config.wait) this.api.page.adminUIApp().waitForHomeScreen();
 			return this;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystone-nightwatch-e2e",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Nightwatch end-to-end testing framework for KeystoneJS applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This PR focused mainly in the refactoring of the app and signin page object API.  Support for front end page testing was added.  Automatic wait for next UI element after taking an action was added (more to do) -- with this tests do not longer need to wait when taking an action (e.g., waiting for the home screen after signing in).  Tests can still choose to disable automatic waiting in case they want to wait for something other than the default target UI.  Javadocs were applied to all methods and elements.
