### PR TITLE
Ensure sauce connection is closed on errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ function runNightwatch (done) {
 }
 
 var sauceConnection = null;
+var sauceConnectionRunning = false;
 
 function sauceConnectLog (message) {
 	console.log([moment().format('HH:mm:ss:SSS')] + ' Sauce Connect: ' + message);
@@ -81,6 +82,7 @@ function startSauceConnect (done) {
 			}
 			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: Sauce Connect Ready');
 			sauceConnection = sauceConnectProcess;
+			sauceConnectionRunning = true;
 			done();
 		});
 	} else {
@@ -93,6 +95,7 @@ function stopSauceConnect (done) {
 		console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: Stopping Sauce Connect');
 		sauceConnection.close(function () {
 			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: Sauce Connect Stopped');
+			sauceConnectionRunning = false;
 			done();
 		});
 	} else {
@@ -146,7 +149,12 @@ function start (options, callback) {
 			selenium_proc.kill('SIGTERM');
 			selenium_proc.kill('SIGKILL');
 		}
-		callback && callback(err);
+		if (sauceConnectionRunning) {
+			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: something seems to have gone wrong, stopping sauce connect before travis shuts down');
+			stopSauceConnect(callback && callback(err));
+		} else {
+			callback && callback(err);
+		}
 	});
 }
 

--- a/index.js
+++ b/index.js
@@ -152,7 +152,7 @@ function start (options, callback) {
 		}
 		if (sauceConnectionRunning) {
 			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: something seems to have gone wrong, stopping sauce connect before travis shuts down');
-			stopSauceConnect(function () {callback && callback(err)});
+			stopSauceConnect(function () { callback && callback(err); });
 		} else {
 			callback && callback(err);
 		}

--- a/index.js
+++ b/index.js
@@ -79,11 +79,12 @@ function startSauceConnect (done) {
 			if (err) {
 				console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: There was an error starting Sauce Connect');
 				done(err);
+			} else {
+				console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: Sauce Connect Ready');
+				sauceConnection = sauceConnectProcess;
+				sauceConnectionRunning = true;
+				done();
 			}
-			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: Sauce Connect Ready');
-			sauceConnection = sauceConnectProcess;
-			sauceConnectionRunning = true;
-			done();
 		});
 	} else {
 		done();
@@ -151,7 +152,7 @@ function start (options, callback) {
 		}
 		if (sauceConnectionRunning) {
 			console.log([moment().format('HH:mm:ss:SSS')] + ' e2e: something seems to have gone wrong, stopping sauce connect before travis shuts down');
-			stopSauceConnect(callback && callback(err));
+			stopSauceConnect(function () {callback && callback(err)});
 		} else {
 			callback && callback(err);
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystone-nightwatch-e2e",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Nightwatch end-to-end testing framework for KeystoneJS applications",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
cc @webteckie 

I think this may (at least help) to solve some of those problems where travis doesn't close the sauce tunnel on error. 

Even if not, I think this is something we should be doing now we're handling the connection manually. What do you think?