### PR TITLE
Added geckodriver

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var child_process = require('child_process');
 var selenium = require('selenium-server-standalone-jar');
 var selenium_proc = null;
 var sauceConnectLauncher = require('sauce-connect-launcher');
+var isWin = /^win/.test(process.platform);
 
 /*
 On some machines, selenium fails with a timeout error when nightwatch tries to connect due to a
@@ -47,6 +48,10 @@ function runNightwatch (done) {
 	try {
 		Nightwatch.cli(function (argv) {
 			// Set app-specific env for nightwatch session
+
+			if (isWin && argv.env === 'default') {
+				argv.e = argv.env = 'firefox-windows';
+			}
 
 			// If possible, argv inputs and environment variables will be merged together
 			// If not, argv inputs will override environment variables.

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -9,6 +9,8 @@ module.exports = (function (settings) {
 	settings.test_settings.default.exclude = process.env.KNE_EXCLUDE_TEST_PATHS.split(',');
 	settings.globals_path = path.resolve(__dirname, 'globals.js');
 	settings.test_settings['saucelabs-travis'].desiredCapabilities['tunnel-identifier'] = process.env.TRAVIS_JOB_NUMBER;
+	settings.test_settings.default.cli_args['webdriver.gecko.driver'] = path.resolve(__dirname, 'node_modules/.bin/geckodriver');
+	settings.test_settings['firefox-windows'].cli_args['webdriver.gecko.driver'] = path.resolve(__dirname, 'node_modules/geckodriver/geckodriver.exe');
 	return settings;
 
 })(require('./nightwatch.json'));

--- a/nightwatch.json
+++ b/nightwatch.json
@@ -27,7 +27,22 @@
       "desiredCapabilities": {
         "browserName": "firefox",
         "javascriptEnabled": true,
-        "acceptSslCerts": true
+        "acceptSslCerts": true,
+        "marionette": true
+      },
+      "cli_args": {
+        "webdriver.gecko.driver": ""
+      }
+    },
+    "firefox-windows": {
+      "desiredCapabilities": {
+        "browserName": "firefox",
+        "javascriptEnabled": true,
+        "acceptSslCerts": true,
+        "marionette": true
+      },
+      "cli_args": {
+        "webdriver.gecko.driver": ""
       }
     },
     "saucelabs-travis": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keystone-nightwatch-e2e",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Nightwatch end-to-end testing framework for KeystoneJS applications",
   "main": "index.js",
   "repository": {
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "async": "^2.0.1",
+    "geckodriver": "^1.3.0",
     "i": "^0.3.5",
     "keystone-utils": "^0.4.0",
     "lodash": "^4.15.0",


### PR DESCRIPTION
@webteckie and @bassjacob could you test this? 
Pull this PR down and then `npm link` it under keystone, the tests should run. 

@webteckie You'll have to use `--env firefox-windows`. This shouldn't actually be necessary, as `node_modules/.bin/geckodriver` should work on Windows too as per [this issue](https://github.com/vladikoff/node-geckodriver/issues/2), where I've asked for help. If you've any ideas for how to get this working otherwise, that'd be good. 